### PR TITLE
FPGA mode LCD driving tweaks

### DIFF
--- a/ili9341.c
+++ b/ili9341.c
@@ -334,16 +334,12 @@ esp_err_t ili9341_deinit(ILI9341* device) {
     }
     res = gpio_set_direction(device->pin_dcx, GPIO_MODE_INPUT);
     if (res != ESP_OK) return res;
-    res = gpio_set_direction(device->pin_cs, GPIO_MODE_OUTPUT);
-    if (res != ESP_OK) return res;
-    res = ili9341_select(device, false);
+    res = gpio_set_direction(device->pin_cs, GPIO_MODE_INPUT);
     if (res != ESP_OK) return res;
     if (device->callback != NULL) {
         device->callback(true);
     }
     res = ili9341_reset(device);
-    if (res != ESP_OK) return res;
-    res = ili9341_select(device, true);
     if (res != ESP_OK) return res;
     return res;
 }

--- a/ili9341.c
+++ b/ili9341.c
@@ -165,8 +165,10 @@ esp_err_t ili9341_reset(ILI9341* device) {
         ESP_LOGI(TAG, "reset");
         esp_err_t res = gpio_set_level(device->pin_reset, false);
         if (res != ESP_OK) return res;
+        res = gpio_set_direction(device->pin_reset, GPIO_MODE_OUTPUT);
+        if (res != ESP_OK) return res;
         vTaskDelay(50 / portTICK_PERIOD_MS);
-        res = gpio_set_level(device->pin_reset, true);
+        res = gpio_set_direction(device->pin_reset, GPIO_MODE_INPUT);
         if (res != ESP_OK) return res;
         vTaskDelay(50 / portTICK_PERIOD_MS);
     } else {
@@ -269,12 +271,6 @@ esp_err_t ili9341_init(ILI9341* device) {
     }*/
     
     if (device->mutex != NULL) xSemaphoreGive(device->mutex);
-    
-    //Initialize reset GPIO pin
-    if (device->pin_reset >= 0) {
-        res = gpio_set_direction(device->pin_reset, GPIO_MODE_OUTPUT);
-        if (res != ESP_OK) return res;
-    }
 
     //Initialize data/clock select GPIO pin
     res = gpio_set_direction(device->pin_dcx, GPIO_MODE_OUTPUT);


### PR DESCRIPTION
This tries to implement closer what's described in the docs :
 - When the mode is set to FPGA, the FPGA controls things and the ESP is as passive as possible
 - Drive reset open drain / Don't drive any other pins when not selected